### PR TITLE
Added google calendar example (#19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "github": "node -r dotenv/config -r ts-node/register src/github.ts",
     "google-sheets": "node -r dotenv/config -r ts-node/register src/google-sheets.ts",
     "google-drive": "node -r dotenv/config -r ts-node/register src/google-drive.ts",
+    "google-calendar": "node -r dotenv/config -r ts-node/register src/google-calendar.ts",
     "twilio": "node -r dotenv/config -r ts-node/register src/twilio.ts",
     "shopify": "node -r dotenv/config -r ts-node/register src/shopify.ts",
     "gmail": "node -r dotenv/config -r ts-node/register src/gmail.ts",

--- a/src/google-calendar.ts
+++ b/src/google-calendar.ts
@@ -1,0 +1,67 @@
+import { TriggerClient, eventTrigger } from "@trigger.dev/sdk";
+import { google } from "googleapis";
+import { JWT } from "google-auth-library";
+import z from "zod";
+
+const client = new TriggerClient({ id: "api-reference" });
+
+// Create a service account and project: https://cloud.google.com/iam/docs/service-account-overview
+// Create a JWT (JSON Web Token) authentication instance for Google APIs.
+// https://cloud.google.com/nodejs/docs/reference/google-auth-library/latest/google-auth-library/jwt
+// Make sure to add the service account email to the calendar you want to access as "Make changes to manage" https://support.google.com/calendar/answer/37082?hl=en
+const auth = new JWT({
+  email: process.env.GOOGLE_CLIENT_EMAIL, // The email associated with the service account
+  key: process.env.GOOGLE_PRIVATE_KEY!.split(String.raw`\n`).join("\n"), // The private key associated with the service account
+  scopes: ["https://www.googleapis.com/auth/calendar"], // The desired scope for accessing Google Calendar
+});
+
+// Initialize the Google Calendar API
+// You have to enable the Google Calendar API https://console.cloud.google.com/apis/
+const calendar = google.calendar({ version: "v3", auth });
+
+client.defineJob({
+  id: "google-calendar-event-create",
+  name: "Google Calendar Event Create",
+  version: "1.0.0",
+  trigger: eventTrigger({
+    name: "google-calendar",
+    schema: z.object({
+      calendarId: z.string(), // The calendar ID is under the Integrate Calendar section of the calendar settings
+      summary: z.string(),
+      description: z.string().optional(),
+      start: z.string(), // Format as ISO 8601 datetime string. Ex: "2021-08-01T12:00:00.000Z"
+      end: z.string(),
+    }),
+  }),
+  run: async (payload, io, ctx) => {
+    const { calendarId, summary, description, start, end } = payload;
+
+    // Wrap an SDK call in io.runTask so it's resumable and displays in logs
+    await io.runTask(
+      "Google Calendar create event",
+      async () => {
+        const requestBody = {
+          summary,
+          description,
+          start: {
+            dateTime: start,
+            timeZone: "UTC", // Adjust to the desired time zone
+          },
+          end: {
+            dateTime: end,
+            timeZone: "UTC",
+          },
+        };
+
+        await calendar.events.insert({ calendarId, requestBody });
+      },
+
+      // Add metadata to the task to improve the display in the logs
+      { name: "Google Calendar create event", icon: "calendar" }
+    );
+  },
+});
+
+// These lines can be removed if you don't want to use express
+import { createExpressServer } from "@trigger.dev/express";
+createExpressServer(client);


### PR DESCRIPTION
Issue: #19

## Summary
I have created an example how to add an event to the calendar.

## Simple input
```json
{
  "end": "2023-10-25T12:00:00Z",
  "start": "2023-10-25T10:00:00Z",
  "summary": "Event Summary",
  "calendarId": "primary", // The calendar ID is under the Integrate Calendar section of the calendar settings
  "description": "Event Description"
}
```

## Screen recording
[Google-Calendar-Example.webm](https://github.com/triggerdotdev/api-reference/assets/43641536/aae1e712-a4b2-41ec-b9ce-2569a06d615a)
