### PR TITLE
Add Salesforce HTTP endpoint example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,7 @@ SF_LOGIN_URL=https://login.salesforce.com
 SF_USERNAME=
 SF_PASSWORD=
 SF_TOKEN=
+SF_WEBHOOK_SIGNING_SECRET=
 
 # Snyk
 SNYK_BASE_URL=https://api.snyk.io/v1

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "novu-http-endpoint": "node -r dotenv/config -r ts-node/register src/novu-http-endpoint.ts",
     "reddit": "node -r dotenv/config -r ts-node/register src/reddit.ts",
     "salesforce": "node -r dotenv/config -r ts-node/register src/salesforce.ts",
+    "salesforce-http-endpoint": "node -r dotenv/config -r ts-node/register src/salesforce-http-endpoint.ts",
     "segment": "node -r dotenv/config -r ts-node/register src/segment.ts",
     "shopify": "node -r dotenv/config -r ts-node/register src/shopify.ts",
     "snyk": "node -r dotenv/config -r ts-node/register src/snyk.ts",

--- a/src/salesforce-http-endpoint.ts
+++ b/src/salesforce-http-endpoint.ts
@@ -4,7 +4,13 @@ import { TriggerClient, verifyRequestSignature } from '@trigger.dev/sdk';
 const client = new TriggerClient({ id: 'api-reference' });
 // end-hide-code
 
-//create an HTTP Endpoint, with the Salesforce details
+// Create an HTTP Endpoint to listen to Salesforce webhooks
+// (This will create the endpoint URL and Secret on the `trigger.dev` dashboard)
+// Salesforce does not built-in webhooks. `Object Triggers` and `Callouts` can be used to simulate them.
+// Setup the `Trigger` on the required Object. The `Callout` has to be marked async in order to work.
+// The `Callout` has to execute a HTTP request to the endpoint URL on the dashboard with the necessary data.
+// It has to compute a HMAC sign for the webhook body using the Secret from `trigger.dev` dashboard.
+// Set the `SF_WEBHOOK_SIGNING_SECRET` (Secret) in the .env file.
 const salesforce = client.defineHttpEndpoint({
   id: 'salesforce',
   source: 'salesforce.com',
@@ -21,7 +27,7 @@ const salesforce = client.defineHttpEndpoint({
 
 client.defineJob({
   id: 'http-salesforce',
-  name: 'HTTP salesforce',
+  name: 'HTTP Salesforce',
   version: '1.0.0',
   enabled: true,
   //create a trigger from the HTTP endpoint

--- a/src/salesforce-http-endpoint.ts
+++ b/src/salesforce-http-endpoint.ts
@@ -1,0 +1,39 @@
+import { TriggerClient, verifyRequestSignature } from '@trigger.dev/sdk';
+
+// hide-code
+const client = new TriggerClient({ id: 'api-reference' });
+// end-hide-code
+
+//create an HTTP Endpoint, with the Salesforce details
+const salesforce = client.defineHttpEndpoint({
+  id: 'salesforce',
+  source: 'salesforce.com',
+  icon: 'salesforce',
+  verify: async request => {
+    return await verifyRequestSignature({
+      request,
+      headerName: 'X-SF-Signature-256',
+      secret: process.env.SF_WEBHOOK_SIGNING_SECRET!,
+      algorithm: 'sha256',
+    });
+  },
+});
+
+client.defineJob({
+  id: 'http-salesforce',
+  name: 'HTTP salesforce',
+  version: '1.0.0',
+  enabled: true,
+  //create a trigger from the HTTP endpoint
+  trigger: salesforce.onRequest(),
+  run: async (request, io, ctx) => {
+    const body = await request.json();
+    await io.logger.info(`Body`, body);
+  },
+});
+
+// hide-code
+// These lines can be removed if you don't want to use express
+import { createExpressServer } from '@trigger.dev/express';
+createExpressServer(client);
+// end-hide-code


### PR DESCRIPTION
Closes #89 

### Testing

Salesforce does not have `webhooks` built into their system.
I've created [Object Triggers](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_triggers.htm) and [HTTP Callouts](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_callouts.htm) to simulate them (more on the video).

In the HTTP Callout, I've created the `X-SF-Signature-256` using the trigger.dev `Secret`, which will be used to verify the webhook authenticity.

### Screen Recording
https://github.com/triggerdotdev/api-reference/assets/132386067/103cf2d2-90f3-478b-89e0-20916db0d08b

